### PR TITLE
Implement `Accordion` and `AccordionGroup` components

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Opinionated vue UI library for building personal applications. Completely from s
   - [ ] Multiselect
   - [ ] Group options by title
   - [ ] Option can have start icon
-- [ ] Accordion
+- [x] Accordion
 - [ ] InputOTP
   - [ ] Wrapper
   - [ ] Slot

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Opinionated vue UI library for building personal applications. Completely from s
   - [ ] Group options by title
   - [ ] Option can have start icon
 - [ ] Accordion
+- [ ] InputOTP
+  - [ ] Wrapper
+  - [ ] Slot
 - [x] Alert
 - [x] Divider
 - [x] Badge

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,15 +20,17 @@ const tab = ref('home')
       Welcome to VUI
     </div>
     <div v-if="tab === 'components'">
-      <Accordion label="See more">
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
-      </Accordion>
-      <Accordion label="See Less">
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
-      </Accordion>
-      <Accordion label="See Idk What you want Bro">
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
-      </Accordion>
+      <AccordionGroup>
+        <Accordion label="See more">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+        </Accordion>
+        <Accordion label="See Less">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+        </Accordion>
+        <Accordion label="See Idk What you want Bro">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+        </Accordion>
+      </AccordionGroup>
     </div>
     <div v-else-if="tab === 'typography'" class="article" :style="{ maxWidth: '688px', margin: 'auto' }">
       <h1>The Joke Tax Chronicles</h1>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,252 +1,36 @@
 <script setup lang="ts">
-import { Icon } from '@iconify/vue'
 import { ref } from 'vue'
 import Accordion from './components/Accordion/Accordion.vue'
 import AccordionGroup from './components/Accordion/AccordionGroup.vue'
-import Alert from './components/Alert/Alert.vue'
-import Avatar from './components/Avatar/Avatar.vue'
-import Badge from './components/Badge/Badge.vue'
-import Button from './components/Button/Button.vue'
-import Card from './components/Card/Card.vue'
-import Checkbox from './components/Checkbox/Checkbox.vue'
-import Divider from './components/Divider/Divider.vue'
-import Flex from './components/Flex/Flex.vue'
-import Input from './components/Input/Input.vue'
-import Textarea from './components/Input/Textarea.vue'
-import Modal from './components/Modal/Modal.vue'
-import Radio from './components/Radio/Radio.vue'
-import RadioGroup from './components/Radio/RadioGroup.vue'
-import Sheet from './components/Sheet/Sheet.vue'
-import Switch from './components/Switch/Switch.vue'
+
 import Tab from './components/Tabs/Tab.vue'
 import Tabs from './components/Tabs/Tabs.vue'
-import { pushToast, removeToast } from './components/Toast/toast'
-import Toasts from './components/Toast/Toasts.vue'
 
-const checked1 = ref(false)
-const checked2 = ref(false)
-const input1 = ref('')
-const textarea = ref('')
 const tab = ref('home')
-const modal = ref(false)
-const sheet = ref(false)
-const radioModel = ref('Andrew')
-const radioOptions = ['Kasper', 'Andrew', 'Jan', 'Felix']
 </script>
 
 <template>
   <div>
-    <Tabs v-model="tab">
+    <Tabs v-model="tab" expand style="margin-bottom: 64px;">
       <Tab id="home" label="Home" icon="ph:house" />
       <Tab id="components" label="Components" />
       <Tab id="typography" label="Typography" />
     </Tabs>
-    <br>
     <div v-if="tab === 'home'">
       Welcome to VUI
     </div>
     <div v-if="tab === 'components'">
-      <Tabs v-model="tab" expand>
-        <Tab id="home" label="Home" icon="ph:house" />
-        <Tab id="components" label="Components" />
-        <Tab id="typography" label="Typography" />
-      </Tabs>
-
-      <br><br><br>
-
-      <AccordionGroup single>
-        <Accordion label="See more" open>
-          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
-        </Accordion>
-        <Accordion label="See more">
-          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
-        </Accordion>
-        <Accordion label="See more">
-          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
-        </Accordion>
-      </AccordionGroup>
-
-      <br>
-      <br>
-      <br>
-      <Flex>
-        <Badge>Neutral</Badge>
-        <Badge variant="info">
-          Info
-        </Badge>
-        <Badge variant="success">
-          Success
-        </Badge>
-        <Badge variant="warning">
-          Warning
-        </Badge>
-        <Badge variant="danger">
-          Danger
-        </Badge>
-        <Badge outline>
-          Neutral
-        </Badge>
-        <Badge filled>
-          Neutral
-        </Badge>
-        <Badge filled variant="info">
-          Info
-        </Badge>
-        <Badge filled variant="success">
-          Success
-        </Badge>
-        <Badge filled variant="warning">
-          Warning
-        </Badge>
-        <Badge filled variant="danger">
-          Danger
-        </Badge>
-      </Flex>
-      <Divider />
-
-      <Flex align-center>
-        <RadioGroup v-model="radioModel" :gap="32">
-          <Radio v-for="item of radioOptions" :key="item" :disabled="item === 'Jan'" :value="item" />
-        </RadioGroup>
-        <Divider vertical />
-
-        {{ radioModel }}
-      </Flex>
-      <br>
-      <br>
-      <Alert title="We chilling" description="This just kinda looks like card with an icon bro we smokin">
-        <template #end>
-          <Button square plain icon="ph:x" />
-        </template>
-      </Alert>
-      <br>
-      <Alert variant="info" title="Hello world" description="This is your new profile page" />
-      <br>
-      <Alert variant="success" title="Sucess!!" description="Update your profile to the latest data or something" />
-      <br>
-      <Alert variant="warning" title="This action has consequences" description="Your account will be affected by this action." />
-      <br>
-      <Alert variant="danger" title="Are you sure?" description="This will delete all your saved data" />
-      <br>
-      <Card>
-        <template #header>
-          <h3>
-            Hello world
-          </h3>
-          <p>I bring some good stuff</p>
-        </template>
-        <template #header-end>
-          <Button square icon="ph:x" />
-        </template>
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Asperiores vero, eius molestiae voluptate veniam nesciunt cupiditate? Impedit tempora quae, asperiores assumenda modi qui in aliquam tenetur? Minus assumenda quam vel.</p>
-        <template #footer>
-          <Button>Save</Button>
-        </template>
-      </Card>
-      <br>
-      <Flex>
-        <Button>Hello</Button>
-        <Button variant="danger">
-          Hello
-        </Button>
-        <Button variant="success">
-          Hello
-        </Button>
-        <Button plain>
-          Hello
-        </Button>
-        <Button disabled>
-          Hello
-        </Button>
-        <Button icon="solar:alt-arrow-right-linear" />
-      </Flex>
-      <Divider />
-      <Checkbox v-model="checked1" label="I hereby surrender my human rights" disabled />
-      <Divider />
-      <Switch v-model="checked2" label="I hereby turn my airplane mode on." />
-      <Divider />
-      <Flex :gap="24">
-        <Input v-model="input1" expand label="Your name" hint="Like what did your mommy call you?" limit="50" />
-        <Textarea v-model="textarea" resize="vertical" expand label="Your name" placeholder="Please tell us why you're here" />
-      </Flex>
-
-      <Divider />
-      <Button
-        @click="pushToast('Created new event', {
-          description: `Event will happen at ${new Date().toISOString()}`,
-          persist: true,
-          action: {
-            label: 'Ok',
-            handler(toastId) {
-              removeToast(toastId)
-            },
-          },
-        })"
-      >
-        Push Toast
-      </Button>
-      <Toasts />
-      <Divider />
-      <Flex>
-        <Avatar url="https://i.imgur.com/xTbZ8nd.png" size="s" />
-        <Avatar url="https://i.imgur.com/xTbZ8nd.png" size="m" />
-        <Avatar url="https://i.imgur.com/xTbZ8nd.png" size="l" />
-        <Divider :size="48" vertical>
-          <Avatar size="s" icon="ph:arrow-right" />
-        </Divider>
-        <Avatar url="https://i.imgur.com/xTbZ8nd____.png" size="s" fallback="HD" />
-        <Avatar url="https://i.imgur.com/xTbZ8nd____.png" size="m" fallback="HD" />
-        <Avatar url="https://i.imgur.com/xTbZ8nd____.png" size="l" fallback="HD" />
-        <Divider :size="48" vertical>
-          <Avatar size="s" icon="ph:arrow-right" />
-        </Divider>
-        <Avatar size="s" />
-        <Avatar size="m" />
-        <Avatar size="l" />
-      </Flex>
-
-      <Divider />
-
-      <Button @click="modal = true">
-        Open modal
-      </Button>
-      <Modal v-model="modal" :card="{ headerSeparator: true }" scrollable centered>
-        <template #header>
-          <h1 style="font-size: 3rem; font-weight: 600;">
-            Confirm
-          </h1>
-        </template>
-        <p>Confirm you are kinda done Lorem ipsum dolor sit amet consectetur adipisicing elit. Itaque odit, recusandae possimus eveniet architecto corporis natus eligendi incidunt quas, blanditiis nemo, dolor alias! Maiores rerum perferendis consequatur impedit. Ipsa, explicabo?</p>
-        <!-- <div style="height: 80vh;" /> -->
-        <!-- Nullam nec pulvinar justo. Curabitur ante dui, tristique eget viverra vitae, pretium nec mi. Integer in nibh faucibus, sollicitudin turpis id, condimentum risus. Aliquam sit amet elementum orci. Integer nisl tellus, venenatis vitae molestie a, laoreet at sem. Vivamus malesuada dolor purus, vitae sollicitudin lacus fringilla at. Sed egestas urna vulputate mauris pulvinar congue. Aliquam aliquet facilisis tortor, sit amet hendrerit ante. Cras pulvinar, magna eget viverra facilisis, velit erat efficitur dui, non pellentesque ipsum sem in ipsum. Morbi eleifend orci lacus, ut porttitor leo blandit nec. Vivamus condimentum nisl at sodales aliquam. In elementum laoreet enim, nec sagittis nisi malesuada id. Nulla interdum cursus quam, eget ultricies sem fringilla vel. -->
-        <template #footer="{ close }">
-          <Flex justify-end>
-            <Button @click="close">
-              Cancel
-            </Button>
-            <Button variant="danger">
-              Delete
-            </Button>
-          </Flex>
-        </template>
-      </Modal>
-      <Divider />
-
-      <Button @click="sheet = true">
-        Open sheet
-      </Button>
-      <Sheet v-model="sheet" separator position="right">
-        <template #header>
-          <h1 style="font-size: 3rem; font-weight: 600;">
-            Edit user
-          </h1>
-        </template>
-        <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ab dolorum debitis beatae, accusantium natus provident ullam fugiat magnam delectus illum reprehenderit error reiciendis similique tenetur minima incidunt at iste exercitationem?</p>
-      <!-- <div style="height: 80vh;" /> -->
-      <!-- <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ab dolorum debitis beatae, accusantium natus provident ullam fugiat magnam delectus illum reprehenderit error reiciendis similique tenetur minima incidunt at iste exercitationem?</p> -->
-      </Sheet>
+      <Accordion label="See more">
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+      </Accordion>
+      <Accordion label="See Less">
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+      </Accordion>
+      <Accordion label="See Idk What you want Bro">
+        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+      </Accordion>
     </div>
-    <div v-else-if="tab === 'typography'" class="article" :style="{ maxWidth: '688px', margin: 'auto', paddingTop: '64px' }">
+    <div v-else-if="tab === 'typography'" class="article" :style="{ maxWidth: '688px', margin: 'auto' }">
       <h1>The Joke Tax Chronicles</h1>
       <p>Once upon a time, in a far-off land, there <code>was a very lazy</code> king who spent all day lounging on his throne. One day, his advisors came to him with a problem: the kingdom was running out of money</p>
       <h2>The King's Plan</h2>
@@ -318,10 +102,4 @@ const radioOptions = ['Kasper', 'Andrew', 'Jan', 'Felix']
       <p>The moral of the story is: never underestimate the power of a good laugh and always be careful of bad ideas.</p>
     </div>
   </div>
-  <br>
-  <br>
-  <br>
-  <br>
-  <br>
-  <br>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { ref } from 'vue'
+import Accordion from './components/Accordion/Accordion.vue'
+import AccordionGroup from './components/Accordion/AccordionGroup.vue'
 import Alert from './components/Alert/Alert.vue'
 import Avatar from './components/Avatar/Avatar.vue'
 import Badge from './components/Badge/Badge.vue'
@@ -49,6 +51,23 @@ const radioOptions = ['Kasper', 'Andrew', 'Jan', 'Felix']
         <Tab id="components" label="Components" />
         <Tab id="typography" label="Typography" />
       </Tabs>
+
+      <br><br><br>
+
+      <AccordionGroup single>
+        <Accordion label="See more" open>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+        </Accordion>
+        <Accordion label="See more">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+        </Accordion>
+        <Accordion label="See more">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Tempora obcaecati excepturi sed enim architecto. Natus iste enim a porro, expedita minima debitis nobis, magni impedit repellendus odit dignissimos blanditiis modi!</p>
+        </Accordion>
+      </AccordionGroup>
+
+      <br>
+      <br>
       <br>
       <Flex>
         <Badge>Neutral</Badge>

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import { ref, useTemplateRef, watch } from 'vue'
+import { onMounted, ref, useTemplateRef, watch, watchEffect } from 'vue'
 import './accordion.scss'
 
 export interface AccordionProps {
@@ -9,14 +9,20 @@ export interface AccordionProps {
 }
 
 const props = defineProps<AccordionProps>()
-
 const emits = defineEmits<{
   open: []
   close: []
 }>()
-const isOpen = ref(!!props.open)
+
+const isOpen = ref(false)
 const content = useTemplateRef('content')
 const contentMaxHeight = ref(0)
+
+watchEffect(() => {
+  isOpen.value = props.open
+}, {
+  flush: 'post',
+})
 
 watch(isOpen, (value) => {
   if (value) {
@@ -28,6 +34,7 @@ watch(isOpen, (value) => {
   }
 }, {
   flush: 'post',
+  immediate: true,
 })
 
 function open() {
@@ -54,7 +61,7 @@ function toggle() {
       <Icon icon="ph:caret-down" />
     </button>
 
-    <div ref="content" class="vui-accordion-content" :style="{ 'max-height': isOpen ? `${contentMaxHeight}px` : 0 }">
+    <div ref="content" class="vui-accordion-content" :style="{ 'max-height': isOpen ? `${contentMaxHeight}px` : '0px' }">
       <slot />
     </div>
   </div>

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue'
+import { ref, useTemplateRef, watch } from 'vue'
+import './accordion.scss'
+
+export interface AccordionProps {
+  open?: boolean
+  label?: string
+}
+
+const props = defineProps<AccordionProps>()
+
+const emits = defineEmits<{
+  open: []
+  close: []
+}>()
+const isOpen = ref(!!props.open)
+const content = useTemplateRef('content')
+const contentMaxHeight = ref(0)
+
+watch(isOpen, (value) => {
+  if (value) {
+    emits('open')
+    contentMaxHeight.value = content.value?.scrollHeight || 0
+  }
+  else {
+    emits('close')
+  }
+}, {
+  flush: 'post',
+})
+
+function open() {
+  isOpen.value = true
+}
+
+function close() {
+  isOpen.value = false
+}
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+</script>
+
+<template>
+  <div class="vui-accordion" :class="{ open: isOpen }">
+    <!-- Completely custom header which needs to be styled and implemented by the developer -->
+    <slot v-if="$slots.trigger" name="trigger" :open :close :toggle :is-open />
+    <button v-else class="vui-accordion-header" @click="isOpen = !isOpen">
+      <slot name="header">
+        {{ props.label }}
+      </slot>
+      <Icon icon="ph:caret-down" />
+    </button>
+
+    <div ref="content" class="vui-accordion-content" :style="{ 'max-height': isOpen ? `${contentMaxHeight}px` : 0 }">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import { onMounted, ref, useTemplateRef, watch, watchEffect } from 'vue'
+import { ref, useTemplateRef, watch, watchEffect } from 'vue'
 import './accordion.scss'
 
 export interface AccordionProps {
@@ -48,6 +48,13 @@ function close() {
 function toggle() {
   isOpen.value = !isOpen.value
 }
+
+defineExpose({
+  open,
+  close,
+  toggle,
+  isOpen,
+})
 </script>
 
 <template>

--- a/src/components/Accordion/AccordionGroup.vue
+++ b/src/components/Accordion/AccordionGroup.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { VNode } from 'vue'
+import type { AccordionProps } from './Accordion.vue'
+import { ref } from 'vue'
+// Renderless component which is used to house multiple accordions which can be triggered together in some way
+
+interface Props {
+  /**
+   * If set to true, if an accordion opens, all other close
+   */
+  single?: boolean
+}
+
+const props = defineProps<Props>()
+
+const slots = defineSlots<{
+  default: () => Array<VNode & { props: AccordionProps }>
+}>()
+
+const activeIndex = ref(
+  slots.default().findIndex(vnode => !!vnode.props.open),
+)
+
+console.log(slots.default())
+
+function handleAccordionOpen(newIndex: number) {
+  if (props.single) {
+    activeIndex.value = newIndex
+  }
+}
+</script>
+
+<template>
+  <component
+    :is="item"
+    v-for="(item, index) of slots.default()"
+    :key="item"
+    :open="index === activeIndex"
+    @open="handleAccordionOpen(index)"
+  />
+</template>

--- a/src/components/Accordion/AccordionGroup.vue
+++ b/src/components/Accordion/AccordionGroup.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { VNode } from 'vue'
 import type { AccordionProps } from './Accordion.vue'
-import { ref } from 'vue'
+import type Accordion from './Accordion.vue'
+import { useTemplateRef } from 'vue'
 // Renderless component which is used to house multiple accordions which can be triggered together in some way
 
 interface Props {
@@ -17,17 +18,17 @@ const slots = defineSlots<{
   default: () => Array<VNode & { props: AccordionProps }>
 }>()
 
-const activeIndex = ref<number>()
-
-const defaultIndex = slots.default().findIndex(vnode => !!vnode.props.open)
-if (defaultIndex > -1) {
-  activeIndex.value = defaultIndex
-}
+const accordionRefs = useTemplateRef<InstanceType<typeof Accordion>[]>('accordionRefs')
 
 function handleAccordionOpen(newIndex: number) {
-  if (props.single) {
-    activeIndex.value = newIndex
-  }
+  if (!accordionRefs.value || !props.single)
+    return
+
+  accordionRefs.value.forEach((item, index) => {
+    if (index !== newIndex) {
+      item.close()
+    }
+  })
 }
 </script>
 
@@ -35,10 +36,8 @@ function handleAccordionOpen(newIndex: number) {
   <component
     :is="item"
     v-for="(item, index) of slots.default()"
+    ref="accordionRefs"
     :key="item"
-    v-bind="{
-      ...(activeIndex && { open: index === activeIndex }),
-    }"
     @open="handleAccordionOpen(index)"
   />
 </template>

--- a/src/components/Accordion/AccordionGroup.vue
+++ b/src/components/Accordion/AccordionGroup.vue
@@ -17,11 +17,12 @@ const slots = defineSlots<{
   default: () => Array<VNode & { props: AccordionProps }>
 }>()
 
-const activeIndex = ref(
-  slots.default().findIndex(vnode => !!vnode.props.open),
-)
+const activeIndex = ref<number>()
 
-console.log(slots.default())
+const defaultIndex = slots.default().findIndex(vnode => !!vnode.props.open)
+if (defaultIndex > -1) {
+  activeIndex.value = defaultIndex
+}
 
 function handleAccordionOpen(newIndex: number) {
   if (props.single) {
@@ -35,7 +36,9 @@ function handleAccordionOpen(newIndex: number) {
     :is="item"
     v-for="(item, index) of slots.default()"
     :key="item"
-    :open="index === activeIndex"
+    v-bind="{
+      ...(activeIndex && { open: index === activeIndex }),
+    }"
     @open="handleAccordionOpen(index)"
   />
 </template>

--- a/src/components/Accordion/accordion.scss
+++ b/src/components/Accordion/accordion.scss
@@ -1,0 +1,43 @@
+.vui-accordion {
+  width: 100%;
+  transition: var(--transition);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0;
+
+  &.open {
+    padding-bottom: var(--space-m);
+
+    .vui-accordion-header svg {
+      transform: rotate(180deg);
+    }
+  }
+
+  .vui-accordion-header {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-m) 0;
+    color: pointer;
+    font-size: var(--font-size-m);
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+      text-underline-offset: 4px;
+    }
+
+    svg {
+      transition: var(--transition);
+    }
+
+    // padding-bottom: var(--w);
+  }
+
+  .vui-accordion-content {
+    transition: var(--transition);
+    width: 100%;
+    max-height: 0;
+    overflow: hidden;
+  }
+}

--- a/src/components/Accordion/accordion.scss
+++ b/src/components/Accordion/accordion.scss
@@ -35,7 +35,7 @@
   }
 
   .vui-accordion-content {
-    transition: var(--transition);
+    transition: var(--transition-slow);
     width: 100%;
     max-height: 0;
     overflow: hidden;

--- a/src/components/Input/Input.vue
+++ b/src/components/Input/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type InputTypeHTMLAttribute, useAttrs, useId } from 'vue'
+import { type InputTypeHTMLAttribute, useId } from 'vue'
 import '../../style/core.scss'
 import './input.scss'
 

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -1,7 +1,7 @@
 <script setup lang='ts'>
 import type { Sizes } from '../../shared/types'
 import type { Props as CardProps } from '../Card/Card.vue'
-import { Transition, useAttrs } from 'vue'
+import { useAttrs } from 'vue'
 import Backdrop from '../../internal/Backdrop/Backdrop.vue'
 import Button from '../Button/Button.vue'
 import Card from '../Card/Card.vue'

--- a/src/components/Sheet/Sheet.vue
+++ b/src/components/Sheet/Sheet.vue
@@ -1,5 +1,5 @@
 <script setup lang='ts'>
-import { computed, Transition } from 'vue'
+import { computed } from 'vue'
 import Backdrop from '../../internal/Backdrop/Backdrop.vue'
 import Button from '../Button/Button.vue'
 import Divider from '../Divider/Divider.vue'

--- a/src/components/Toast/Toasts.vue
+++ b/src/components/Toast/Toasts.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Teleport, TransitionGroup } from 'vue'
 import Button from '../Button/Button.vue'
 import { toasts } from './toast'
 import './toast.scss'


### PR DESCRIPTION
- Add `Accordion` item. Clicking it will reveal its contents in animated matter. You can also provide a fully custom trigger in case the basic styling isn't enough
- Add `AccordionGroup`. Very simple wrapper element which (if set via the `single` prop) makes sure only a single Accordion is open and automatically closes the previous one
- Clean up testing page
- Clean up unused imports