### PR TITLE
Implement `Resizable`

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import ExampleBadges from './examples/ExampleBadges.vue'
+import ExampleResizeable from './examples/ExampleResizeable.vue'
 import { setColorTheme } from './shared/theme'
 
 setColorTheme('dark')
@@ -7,6 +7,6 @@ setColorTheme('dark')
 
 <template>
   <main vaul-drawer-wrapper class="container-m py-xxxl">
-    <ExampleBadges />
+    <ExampleResizeable />
   </main>
 </template>

--- a/src/components/Resizable/Panel.vue
+++ b/src/components/Resizable/Panel.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const props = defineProps<{
+
+}>()
+</script>
+
+<template>
+  <div />
+</template>

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
+import { ref, useTemplateRef, watch } from 'vue'
+import { useTopLevelSlots } from '../../shared/slots'
+import './resizable.scss'
+
+interface Props {
+  vertical?: boolean
+  persist?: boolean
+}
+
+interface PanelProps {
+  minWidth: number
+  maxWidth: number
+}
+
+const props = defineProps<Props>()
+const slots = defineSlots<{
+  default: (props: PanelProps) => any
+}>()
+
+const root = useTemplateRef('resizableRef')
+const panels = useTopLevelSlots(slots.default)
+
+// When applying defaults, set `flex: <value> 1 0px;
+// While moving, set overflow hidden & pointer events none
+
+interface PanelState {
+  size: number
+  isResizing: boolean
+}
+
+const focusedPanelIndex = ref(-1)
+const panelState = ref<PanelState[]>([])
+
+// Initialize panels
+watch(panels, (items) => {
+  // Initialize from localStorage state if persist is enabled
+  if (props.persist && panelState.value.length) {
+    return
+  }
+
+  panelState.value = items.map(() => ({
+    size: 100 / items.length,
+    isResizing: false,
+  }))
+}, { immediate: true })
+
+useEventListener(root, 'mousedown', (event) => {
+  const handle = (event.target as HTMLElement).closest('.vui-resizable-handle')
+  if (!handle)
+    return
+
+  const index = Number(handle.getAttributeNode('data-handle-index')?.value)
+  if (index === undefined)
+    return
+
+  panelState.value[index].isResizing = true
+
+  const rect = root.value!.getBoundingClientRect()
+  const startX = Math.max(rect.left, Math.min(rect.right, event.clientX))
+  const startSize = panelState.value[index].size
+  const nextStartSize = panelState.value[index + 1].size
+
+  const onMouseMove = (event: MouseEvent) => {
+    const clampedClientX = Math.max(rect.left, Math.min(rect.right, event.clientX))
+    const deltaX = clampedClientX - startX
+    const containerWidth = rect.width
+    if (!containerWidth)
+      return
+
+    const deltaSize = (deltaX / containerWidth) * 100
+
+    panelState.value[index].size = Math.max(0, Math.min(100, startSize + deltaSize))
+    panelState.value[index + 1].size = Math.max(0, Math.min(100, nextStartSize - deltaSize))
+  }
+
+  const onMouseUp = () => {
+    panelState.value[index].isResizing = false
+    window.removeEventListener('mousemove', onMouseMove)
+    window.removeEventListener('mouseup', onMouseUp)
+  }
+
+  window.addEventListener('mousemove', onMouseMove)
+  window.addEventListener('mouseup', onMouseUp)
+})
+</script>
+
+<template>
+  <div ref="resizableRef" class="vui-resizable" :class="{ vertical: props.vertical }">
+    <template v-for="(panel, index) in panels" :key="panel.key">
+      <div
+        class="vui-resizable-panel"
+        :style="{
+          flex: `${panelState[index].size} 1 0px`,
+          pointerEvents: panelState[index].isResizing ? 'none' : 'auto',
+        }"
+      >
+        <Component :is="panel" />
+      </div>
+      <button
+        v-if="index < panels.length - 1"
+        :data-handle-index="index"
+        class="vui-resizable-handle"
+        @focus="focusedPanelIndex = index"
+        @blur="focusedPanelIndex = -1"
+      />
+    </template>
+  </div>
+</template>

--- a/src/components/Resizable/Resizable.vue
+++ b/src/components/Resizable/Resizable.vue
@@ -1,12 +1,23 @@
 <script setup lang="ts">
-import { useEventListener } from '@vueuse/core'
+import { useElementBounding, useEventListener, useStorage } from '@vueuse/core'
 import { ref, useTemplateRef, watch } from 'vue'
+import { clamp } from '../../shared/helpers'
 import { useTopLevelSlots } from '../../shared/slots'
 import './resizable.scss'
 
+// TODO
+// 2. Support for `Panel` and prop handling
+// 3. Invisible divider (only shows up on hover)
+
 interface Props {
+  /**
+   * Enable vertical layout
+   */
   vertical?: boolean
-  persist?: boolean
+  /**
+   * If provided, it enables local persistence of panel sizes
+   */
+  storageKey?: string
 }
 
 interface PanelProps {
@@ -22,23 +33,24 @@ const slots = defineSlots<{
 const root = useTemplateRef('resizableRef')
 const panels = useTopLevelSlots(slots.default)
 
-// When applying defaults, set `flex: <value> 1 0px;
-// While moving, set overflow hidden & pointer events none
-
 interface PanelState {
   size: number
   isResizing: boolean
 }
 
 const focusedPanelIndex = ref(-1)
-const panelState = ref<PanelState[]>([])
 
-// Initialize panels
+const panelState = props.storageKey
+  ? useStorage<PanelState[]>(props.storageKey, [])
+  : ref<PanelState[]>([])
+
+const { left, right, width, top, bottom } = useElementBounding(root)
+
+// Set initial panel sizes on mount or when panels change
 watch(panels, (items) => {
-  // Initialize from localStorage state if persist is enabled
-  if (props.persist && panelState.value.length) {
+  // If numbers of panels is the same as the stored state, do nothing (e.g. on remount)
+  if (panelState.value.length === items.length)
     return
-  }
 
   panelState.value = items.map(() => ({
     size: 100 / items.length,
@@ -46,33 +58,54 @@ watch(panels, (items) => {
   }))
 }, { immediate: true })
 
-useEventListener(root, 'mousedown', (event) => {
+// Returns the index of the currently focused handle
+function getFocusedHandle(event: MouseEvent | KeyboardEvent) {
   const handle = (event.target as HTMLElement).closest('.vui-resizable-handle')
   if (!handle)
     return
 
-  const index = Number(handle.getAttributeNode('data-handle-index')?.value)
+  if (handle.closest('.vui-resizable') !== root.value)
+    return
+
+  return Number(handle.getAttributeNode('data-handle-index')?.value)
+}
+
+function applyResize(index: number, deltaSize: number, baseSize: number, nextBaseSize: number) {
+  panelState.value[index].size = clamp(0, 100, baseSize + deltaSize)
+  panelState.value[index + 1].size = clamp(0, 100, nextBaseSize - deltaSize)
+}
+
+// Controls via mouse drag
+useEventListener(root, 'mousedown', (event) => {
+  const index = getFocusedHandle(event)
+
   if (index === undefined)
     return
 
   panelState.value[index].isResizing = true
 
-  const rect = root.value!.getBoundingClientRect()
-  const startX = Math.max(rect.left, Math.min(rect.right, event.clientX))
+  const startPos = clamp(
+    props.vertical ? top.value : left.value,
+    props.vertical ? bottom.value : right.value,
+    props.vertical ? event.clientY : event.clientX,
+  )
+
   const startSize = panelState.value[index].size
   const nextStartSize = panelState.value[index + 1].size
 
   const onMouseMove = (event: MouseEvent) => {
-    const clampedClientX = Math.max(rect.left, Math.min(rect.right, event.clientX))
-    const deltaX = clampedClientX - startX
-    const containerWidth = rect.width
-    if (!containerWidth)
+    const clampedClientPos = clamp(
+      props.vertical ? top.value : left.value,
+      props.vertical ? bottom.value : right.value,
+      props.vertical ? event.clientY : event.clientX,
+    )
+
+    const delta = clampedClientPos - startPos
+
+    if (!width.value)
       return
 
-    const deltaSize = (deltaX / containerWidth) * 100
-
-    panelState.value[index].size = Math.max(0, Math.min(100, startSize + deltaSize))
-    panelState.value[index + 1].size = Math.max(0, Math.min(100, nextStartSize - deltaSize))
+    applyResize(index, (delta / width.value) * 100, startSize, nextStartSize)
   }
 
   const onMouseUp = () => {
@@ -84,6 +117,34 @@ useEventListener(root, 'mousedown', (event) => {
   window.addEventListener('mousemove', onMouseMove)
   window.addEventListener('mouseup', onMouseUp)
 })
+
+// Controls via keyboard when handle is focused
+useEventListener(root, 'keydown', (event) => {
+  const index = getFocusedHandle(event)
+
+  if (index === undefined)
+    return
+
+  // Control with arrow keys: left/right for horizontal, up/down for vertical but not at once
+  if (((event.key === 'ArrowLeft' || event.key === 'ArrowRight') && !props.vertical) || ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && props.vertical)) {
+    event.preventDefault()
+    const MOVE_BY = 5
+    const delta = (event.key === 'ArrowLeft' || event.key === 'ArrowUp') ? -MOVE_BY : MOVE_BY
+    applyResize(index, delta, panelState.value[index].size, panelState.value[index + 1].size)
+  }
+})
+
+// Reset to default size on double click
+function resetSize(index: number) {
+  // Get width of both current and the next panel.
+  const current = panelState.value[index]
+  const next = panelState.value[index + 1]
+
+  // Set their width so they're both equal
+  const newSize = (current.size + next.size) / 2
+  panelState.value[index].size = newSize
+  panelState.value[index + 1].size = newSize
+}
 </script>
 
 <template>
@@ -102,6 +163,7 @@ useEventListener(root, 'mousedown', (event) => {
         v-if="index < panels.length - 1"
         :data-handle-index="index"
         class="vui-resizable-handle"
+        @dblclick="resetSize(index)"
         @focus="focusedPanelIndex = index"
         @blur="focusedPanelIndex = -1"
       />

--- a/src/components/Resizable/resizable.scss
+++ b/src/components/Resizable/resizable.scss
@@ -36,7 +36,6 @@
   & > .vui-resizable-handle {
     width: 1px;
     position: relative;
-    // height: 100%;
     background-color: var(--color-border);
     align-self: stretch;
     z-index: 2;

--- a/src/components/Resizable/resizable.scss
+++ b/src/components/Resizable/resizable.scss
@@ -1,18 +1,39 @@
-// TODO: vertical
-
 .vui-resizable {
   display: flex;
   flex-direction: row;
   gap: 0;
   align-items: stretch;
 
-  .vui-resizable-panel {
+  &.vertical {
+    flex-direction: column;
+
+    & > .vui-resizable-handle {
+      cursor: ns-resize;
+      height: 1px;
+      width: 100%;
+
+      &:after {
+        left: 50%;
+        top: -2px;
+        transform: translateX(-50%);
+        width: 32px;
+        height: unset;
+        bottom: -2px;
+      }
+
+      &:before {
+        inset: -6px 0;
+      }
+    }
+  }
+
+  & > .vui-resizable-panel {
     display: block;
     z-index: 1;
     overflow: hidden;
   }
 
-  .vui-resizable-handle {
+  & > .vui-resizable-handle {
     width: 1px;
     position: relative;
     // height: 100%;

--- a/src/components/Resizable/resizable.scss
+++ b/src/components/Resizable/resizable.scss
@@ -1,0 +1,54 @@
+// TODO: vertical
+
+.vui-resizable {
+  display: flex;
+  flex-direction: row;
+  gap: 0;
+  align-items: stretch;
+
+  .vui-resizable-panel {
+    display: block;
+    z-index: 1;
+    overflow: hidden;
+  }
+
+  .vui-resizable-handle {
+    width: 1px;
+    position: relative;
+    // height: 100%;
+    background-color: var(--color-border);
+    align-self: stretch;
+    z-index: 2;
+    cursor: ew-resize;
+
+    &:focus-within,
+    &:hover {
+      background-color: var(--color-border-strong);
+
+      &:after {
+        background-color: var(--color-border-strong);
+      }
+    }
+
+    // Hover area
+    &:before {
+      content: '';
+      position: absolute;
+      z-index: -1;
+      inset: 0 -6px;
+    }
+
+    // Handle
+    &:after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      left: -2px;
+      right: -2px;
+      height: 32px;
+      border-radius: var(--border-radius-pill);
+      background-color: var(--color-border);
+    }
+  }
+}

--- a/src/examples/ExampleResizeable.vue
+++ b/src/examples/ExampleResizeable.vue
@@ -12,13 +12,20 @@ import Resizable from '../components/Resizable/Resizable.vue'
 
     <Card :padding="false">
       <Resizable>
-        <Flex
-          v-for="item in 3"
-          :key="item"
-          class="example-panel" x-center y-center
-        >
-          <p>Panel {{ item }}</p>
+        <Flex class="example-panel" x-center y-center>
+          <p>Panel 1</p>
         </Flex>
+        <Flex class="example-panel" x-center y-center>
+          <p>Panel 2</p>
+        </Flex>
+        <Resizable class="example-panel" vertical>
+          <Flex class="h-100" x-center y-center>
+            <p>Panel 3</p>
+          </Flex>
+          <Flex class="h-100" x-center y-center>
+            <p>Panel 4</p>
+          </Flex>
+        </Resizable>
       </Resizable>
     </Card>
   </div>

--- a/src/examples/ExampleResizeable.vue
+++ b/src/examples/ExampleResizeable.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import Card from '../components/Card/Card.vue'
+import Flex from '../components/Flex/Flex.vue'
+import Resizable from '../components/Resizable/Resizable.vue'
+</script>
+
+<template>
+  <div class="mb-xxl">
+    <h3 class="mb-l">
+      Resizeable
+    </h3>
+
+    <Card :padding="false">
+      <Resizable>
+        <Flex
+          v-for="item in 3"
+          :key="item"
+          class="example-panel" x-center y-center
+        >
+          <p>Panel {{ item }}</p>
+        </Flex>
+      </Resizable>
+    </Card>
+  </div>
+</template>
+
+<style>
+.example-panel {
+  height: 256px;
+}
+</style>

--- a/src/shared/slots.ts
+++ b/src/shared/slots.ts
@@ -2,7 +2,7 @@ import type { ShallowRef, VNode } from 'vue'
 import { computed, Fragment, watchPostEffect } from 'vue'
 
 type VNodesProps<T extends object> = Array<VNode & { props: T }>
-type SlotFn = () => VNode[] | VNode | undefined
+type SlotFn = (props?: any) => VNode[] | VNode | undefined
 
 function getTopLevelSlotNodes(slotFn?: SlotFn): VNode[] {
   const nodes = slotFn?.()


### PR DESCRIPTION
Very little real world usage, but will serve as a base for `ResizableView` component, which will mimic how VSCode and other code editors management windows. Options to resize or split views as much as user wishes to